### PR TITLE
update to JavaCC 6.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 
 dependencies {
     compile gradleApi()
-    compile group: 'net.java.dev.javacc', name: 'javacc', version: '5.0'
+    compile group: 'net.java.dev.javacc', name: 'javacc', version: '6.1.2'
      
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.mockito', name: 'mockito-all', version: '1.9.5'


### PR DESCRIPTION
JavaCC 6 was made available on Maven Central last month, so update to the latest available version.
