### PR TITLE
Changed reference to get project directory from getRootDIr() to getProjectDir()

### DIFF
--- a/src/main/java/ca/coglinc/gradle/plugins/javacc/CompileJavaccTask.java
+++ b/src/main/java/ca/coglinc/gradle/plugins/javacc/CompileJavaccTask.java
@@ -16,7 +16,7 @@ public class CompileJavaccTask extends DefaultTask {
     private static final String DEFAULT_INPUT_DIRECTORY = File.separator + "src" + File.separator + "main" + File.separator + "javacc";
     private static final String DEFAULT_OUTPUT_DIRECTORY = File.separator + "generated" + File.separator + "javacc";
     
-    private File inputDirectory = new File(getProject().getRootDir().getAbsolutePath() + DEFAULT_INPUT_DIRECTORY);
+    private File inputDirectory = new File(getProject().getProjectDir().getAbsolutePath() + DEFAULT_INPUT_DIRECTORY);
     private File outputDirectory = new File(getProject().getBuildDir().getAbsolutePath() + DEFAULT_OUTPUT_DIRECTORY);
     
     @TaskAction


### PR DESCRIPTION
This will allow sub-projects to work as the reference to the javacc source folder is from the project
directory and not the root directory of the multi-project setup.
