### PR TITLE
Changed CompileJavaccTask base class and added default filter

### DIFF
--- a/src/main/java/ca/coglinc/gradle/plugins/javacc/CompileJavaccTask.java
+++ b/src/main/java/ca/coglinc/gradle/plugins/javacc/CompileJavaccTask.java
@@ -2,75 +2,60 @@ package ca.coglinc.gradle.plugins.javacc;
 
 import java.io.File;
 
-import org.gradle.api.DefaultTask;
-import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
 import org.javacc.parser.Main;
 
-public class CompileJavaccTask extends DefaultTask {
+public class CompileJavaccTask extends SourceTask {
     public static final String TASK_NAME_VALUE = "compileJavacc";
     public static final String TASK_DESCRIPTION_VALUE = "Compiles javacc files into java files";
     public static final String JAVACC_GROUP = "JavaCC";
-    
+
     private static final String DEFAULT_INPUT_DIRECTORY = File.separator + "src" + File.separator + "main" + File.separator + "javacc";
     private static final String DEFAULT_OUTPUT_DIRECTORY = File.separator + "generated" + File.separator + "javacc";
-    
+
     private File inputDirectory = new File(getProject().getRootDir().getAbsolutePath() + DEFAULT_INPUT_DIRECTORY);
     private File outputDirectory = new File(getProject().getBuildDir().getAbsolutePath() + DEFAULT_OUTPUT_DIRECTORY);
-    
+
+    public CompileJavaccTask() {
+        setSource(inputDirectory);
+        include("**/*.jj");
+    }
+
     @TaskAction
     public void executeTask() throws Exception {
         outputDirectory.mkdirs();
-        
-        File[] inputFiles = inputDirectory.listFiles();
-        compileInputFilesToJava(inputFiles);
-    }
-    
-    private void compileInputFilesToJava(File[] inputFiles) throws Exception {
-        if (hasInputFiles(inputFiles)) {
-            forEachInputFileCompile(inputFiles);
-        }
-    }
-    
-    private boolean hasInputFiles(File[] inputFiles) {
-        return (inputFiles != null) && (inputFiles.length > 0);
-    }
 
-    private void forEachInputFileCompile(File[] inputFiles) throws Exception {
-        for (File javaccFile : inputFiles) {
-            compileToJava(javaccFile);
+        for (File inputFile : getSource().getFiles()) {
+            compileToJava(inputFile);
         }
     }
 
-    private void compileToJava(File javaccFile) throws Exception {
-        if (javaccFile.isDirectory()) {
-            compileInputFilesToJava(javaccFile.listFiles());
-        } else {
-            int errorCode = Main.mainProgram(new String[] {getJavaccOutputDirectoryOption(javaccFile.getParentFile()), javaccFile.getAbsolutePath()});
-            if (errorCode != 0) {
-                throw new IllegalStateException("Javacc failed with error code: [" + errorCode + "]");
-            }
+    private void compileToJava(File inputFile) throws Exception {
+        int errorCode = Main.mainProgram(new String[]{getJavaccOutputDirectoryOption(inputFile.getParentFile()), inputFile.getAbsolutePath()});
+        if (errorCode != 0) {
+            throw new IllegalStateException("Javacc failed with error code: [" + errorCode + "]");
         }
     }
 
     private String getJavaccOutputDirectoryOption(File parentFile) {
         return "-OUTPUT_DIRECTORY=" + outputDirectory.getAbsolutePath() + parentFile.getAbsolutePath().replace(inputDirectory.getAbsolutePath(), "");
     }
-    
+
     void setInputDirectory(File inputDirectory) {
         this.inputDirectory = inputDirectory;
+        setSource(this.inputDirectory);
     }
-    
+
     void setOutputDirectory(File outputDirectory) {
         this.outputDirectory = outputDirectory;
     }
-    
-    @InputDirectory
+
     public File getInputDirectory() {
         return inputDirectory;
     }
-    
+
     @OutputDirectory
     public File getOutputDirectory() {
         return outputDirectory;

--- a/src/test/java/ca/coglinc/gradle/plugins/javacc/CompileJavaccTaskTest.java
+++ b/src/test/java/ca/coglinc/gradle/plugins/javacc/CompileJavaccTaskTest.java
@@ -1,6 +1,7 @@
 package ca.coglinc.gradle.plugins.javacc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -90,8 +91,7 @@ public class CompileJavaccTaskTest {
 
         task.execute();
 
-        assertTrue(outputDirectory.isDirectory());
-        assertEquals(0, outputDirectory.list().length);
+        assertFalse(outputDirectory.isDirectory());
     }
     
     @Test
@@ -124,20 +124,6 @@ public class CompileJavaccTaskTest {
         task.setOutputDirectory(outputDirectory);
 
         task.execute();
-    }
-    
-    @Test(expected = TaskValidationException.class)
-    public void inputDirectoryIsMandatory() {
-        task.setInputDirectory(null);
-        final File outputDirectory = new File(getClass().getResource("/").getFile() + "output");
-        task.setOutputDirectory(outputDirectory);
-        
-        try {
-            task.execute();
-        } catch (TaskExecutionException e) {
-            assertTrue(e.getCause() instanceof IllegalArgumentException);
-            throw e;
-        }
     }
     
     @Test(expected = TaskValidationException.class)


### PR DESCRIPTION
In our use-case, the input directory contains other stuff than plain JavaCC input files. Here some works to fix this issue.
- The base class for `CompileJavaccTask` is now a `SourceTask`, given us
  access to easy filtering using includes and excludes as well as
  easier handling of source files.
- Added default include filter `**/*.jj` to only use JavaCC input
  files.

The addition of a default include filter could be seen as a BC break. Removing it would be ok since it is now possible to use `include "**/*.jj"` in task configuration to only include certain files.

I had to change some tests because the behavior is a bit more clever now. Output directory is now not created if there is no input files and input directory is not required anymore.

Regards,
Matt
