### PR TITLE
Gradle build cache support for all tasks

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0.2-all.zip

--- a/subprojects/plugin/build.gradle
+++ b/subprojects/plugin/build.gradle
@@ -104,7 +104,7 @@ tasks.withType(FindBugs) {
 task acceptanceTest(type: Test) {
     mustRunAfter test
 
-    testClassesDir = sourceSets.acceptanceTest.output.classesDir
+    testClassesDirs = sourceSets.acceptanceTest.output.classesDirs
     classpath = sourceSets.acceptanceTest.runtimeClasspath
 }
 

--- a/subprojects/plugin/src/acceptanceTest/java/javacc/compilation/CompilationSteps.java
+++ b/subprojects/plugin/src/acceptanceTest/java/javacc/compilation/CompilationSteps.java
@@ -1,20 +1,23 @@
 package javacc.compilation;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.ArrayUtils;
-import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
-import org.gradle.testkit.runner.TaskOutcome;
+import static org.gradle.internal.impldep.org.hamcrest.CoreMatchers.anyOf;
+import static org.gradle.internal.impldep.org.hamcrest.CoreMatchers.is;
+import static org.gradle.internal.impldep.org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class CompilationSteps {
     private File projectDirectory;
@@ -50,6 +53,11 @@ public class CompilationSteps {
         buildRunner.withArguments(allArguments);
         buildRunner.forwardOutput();
 
+        return this;
+    }
+
+    public CompilationSteps withGradleVersion(String version) {
+        buildRunner.withGradleVersion(version);
         return this;
     }
 
@@ -90,5 +98,9 @@ public class CompilationSteps {
 
     public void thenAssertTaskStatus(BuildResult buildResult, String taskPath, TaskOutcome expectedOutcome) {
         assertEquals(expectedOutcome, buildResult.task(taskPath).getOutcome());
+    }
+
+    public void thenAssertTaskWasWithoutSources(BuildResult buildResult, String taskPath) {
+        assertThat(buildResult.task(taskPath).getOutcome(), anyOf(is(TaskOutcome.NO_SOURCE), is(TaskOutcome.UP_TO_DATE)));
     }
 }

--- a/subprojects/plugin/src/acceptanceTest/java/javacc/compilation/ThePluginCompilesJavaccToExpectedDirectoryStory.java
+++ b/subprojects/plugin/src/acceptanceTest/java/javacc/compilation/ThePluginCompilesJavaccToExpectedDirectoryStory.java
@@ -1,7 +1,6 @@
 package javacc.compilation;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.Test;
 
 import java.io.File;
@@ -18,6 +17,37 @@ public class ThePluginCompilesJavaccToExpectedDirectoryStory {
 
         steps.givenAProjectNamed("simpleTest");
         steps.withArguments(CLEAN, COMPILE_JAVACC).execute();
+
+        String buildDirectory = "build" + File.separator + "generated";
+
+        steps.thenAssertOutputDirectoryDoesNotExists(buildDirectory + File.separator + "jjtree");
+
+        steps.thenAssertOutputDirectoryExists(buildDirectory + File.separator + "javacc");
+        steps.andAssertFileWasGenerated("MyParser.java");
+        steps.andAssertFileWasGenerated("MyParserConstants.java");
+        steps.andAssertFileWasGenerated("MyParserTokenManager.java");
+        steps.andAssertFileWasGenerated("ParseException.java");
+        steps.andAssertFileWasGenerated("SimpleCharStream.java");
+        steps.andAssertFileWasGenerated("Token.java");
+        steps.andAssertFileWasGenerated("TokenMgrError.java");
+
+        steps.thenAssertOutputDirectoryExists(buildDirectory + File.separator + "javacc" + File.separator + "test" + File.separator + "pkg");
+        steps.andAssertFileWasGenerated("JavaccOutputTest.java");
+        steps.andAssertFileWasGenerated("JavaccOutputTestConstants.java");
+        steps.andAssertFileWasGenerated("JavaccOutputTestTokenManager.java");
+        steps.andAssertFileWasGenerated("ParseException.java");
+        steps.andAssertFileWasGenerated("SimpleCharStream.java");
+        steps.andAssertFileWasGenerated("Token.java");
+        steps.andAssertFileWasGenerated("TokenMgrError.java");
+    }
+
+    @Test
+    public void givenASimpleProjectOnGradle33() throws URISyntaxException, IOException {
+        CompilationSteps steps = new CompilationSteps();
+
+        steps.givenAProjectNamed("simpleTest");
+        steps.withArguments(CLEAN, COMPILE_JAVACC);
+        steps.withGradleVersion("3.3").execute();
 
         String buildDirectory = "build" + File.separator + "generated";
 
@@ -374,6 +404,6 @@ public class ThePluginCompilesJavaccToExpectedDirectoryStory {
         steps.withArguments(CLEAN, COMPILE_JAVACC).execute();
         BuildResult buildResult = steps.withArguments(COMPILE_JAVACC).execute();
 
-        steps.thenAssertTaskStatus(buildResult, ":compileJavacc", TaskOutcome.NO_SOURCE);
+        steps.thenAssertTaskWasWithoutSources(buildResult, ":compileJavacc");
     }
 }

--- a/subprojects/plugin/src/acceptanceTest/java/javacc/compilation/ThePluginCompilesJavaccToExpectedDirectoryStory.java
+++ b/subprojects/plugin/src/acceptanceTest/java/javacc/compilation/ThePluginCompilesJavaccToExpectedDirectoryStory.java
@@ -1,12 +1,12 @@
 package javacc.compilation;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
 
 public class ThePluginCompilesJavaccToExpectedDirectoryStory {
     private static final String CLEAN = "clean";
@@ -374,6 +374,6 @@ public class ThePluginCompilesJavaccToExpectedDirectoryStory {
         steps.withArguments(CLEAN, COMPILE_JAVACC).execute();
         BuildResult buildResult = steps.withArguments(COMPILE_JAVACC).execute();
 
-        steps.thenAssertTaskStatus(buildResult, ":compileJavacc", TaskOutcome.UP_TO_DATE);
+        steps.thenAssertTaskStatus(buildResult, ":compileJavacc", TaskOutcome.NO_SOURCE);
     }
 }

--- a/subprojects/plugin/src/acceptanceTest/java/javacc/compilation/ThePluginCompilesJjtreeToExpectedDirectoryStory.java
+++ b/subprojects/plugin/src/acceptanceTest/java/javacc/compilation/ThePluginCompilesJjtreeToExpectedDirectoryStory.java
@@ -1,10 +1,10 @@
 package javacc.compilation;
 
+import org.junit.Test;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
-
-import org.junit.Test;
 
 public class ThePluginCompilesJjtreeToExpectedDirectoryStory {
     private static final String CLEAN = "clean";
@@ -13,7 +13,7 @@ public class ThePluginCompilesJjtreeToExpectedDirectoryStory {
     @Test
     public void givenAMultiProjectBuildWithJJTreeWhenExecuteCompileJJTreeTaskThenTheFilesAreGeneratedInTheDefaultDirectory()
         throws URISyntaxException, IOException {
-        
+
         CompilationSteps steps = new CompilationSteps();
 
         steps.givenAProjectNamed("multiprojectBuildWithJJTree");
@@ -34,7 +34,7 @@ public class ThePluginCompilesJjtreeToExpectedDirectoryStory {
     @Test
     public void givenAMultiProjectBuildWithJJTreeThatConfiguresTheInputOutputDirectoriesWhenExecuteCompileJJTreeTaskThenTheFilesAreGeneratedInTheDefaultDirectory()
         throws URISyntaxException, IOException {
-        
+
         CompilationSteps steps = new CompilationSteps();
 
         steps.givenAProjectNamed("multiprojectBuildWithJJTreeAndWithConfiguredInputsOutputs");
@@ -55,7 +55,7 @@ public class ThePluginCompilesJjtreeToExpectedDirectoryStory {
     @Test
     public void givenASimpleJJTreeProjectWhenExecuteCompileJJTreeTaskThenTheFilesAreGeneratedInTheDefaultDirectory() throws URISyntaxException,
         IOException {
-        
+
         CompilationSteps steps = new CompilationSteps();
 
         steps.givenAProjectNamed("simpleJJTreeTest");
@@ -72,11 +72,33 @@ public class ThePluginCompilesJjtreeToExpectedDirectoryStory {
 
         steps.thenAssertOutputDirectoryDoesNotExists(buildDirectory + File.separator + "javacc");
     }
-    
+
+    @Test
+    public void givenASimpleJJTreeProjectWithGradle33() throws URISyntaxException,
+        IOException {
+
+        CompilationSteps steps = new CompilationSteps();
+
+        steps.givenAProjectNamed("simpleJJTreeTest");
+        steps.withArguments(CLEAN, COMPILE_JJ_TREE);
+        steps.withGradleVersion("3.3").execute();
+
+        String buildDirectory = "build" + File.separator + "generated";
+
+        steps.thenAssertOutputDirectoryExists(buildDirectory + File.separator + "jjtree");
+        steps.andAssertFileWasGenerated("JJTreeOutputTest.jj");
+        steps.andAssertFileWasGenerated("HelloTreeConstants.java");
+        steps.andAssertFileWasGenerated("JJTHelloState.java");
+        steps.andAssertFileWasGenerated("Node.java");
+        steps.andAssertFileWasGenerated("SimpleNode.java");
+
+        steps.thenAssertOutputDirectoryDoesNotExists(buildDirectory + File.separator + "javacc");
+    }
+
     @Test
     public void givenASimpleJJTreeProjectWithPackagesWhenExecuteCompileJJTreeTaskThenTheFilesAreGeneratedInThePackageDirectory() throws URISyntaxException,
         IOException {
-        
+
         CompilationSteps steps = new CompilationSteps();
 
         steps.givenAProjectNamed("simpleJJTreeTestWithPackages");
@@ -90,7 +112,7 @@ public class ThePluginCompilesJjtreeToExpectedDirectoryStory {
         steps.andAssertFileWasGenerated("JJTHelloState.java");
         steps.andAssertFileWasGenerated("Node.java");
         steps.andAssertFileWasGenerated("SimpleNode.java");
-        
+
         steps.thenAssertOutputDirectoryExists(buildDirectory + File.separator + "jjtree" + File.separator + "test" + File.separator + "pkg");
         steps.andAssertFileWasGenerated("JJTreeOutputTest.jj");
         steps.andAssertFileWasGenerated("HelloTreeConstants.java");
@@ -104,7 +126,7 @@ public class ThePluginCompilesJjtreeToExpectedDirectoryStory {
     @Test
     public void givenASimpleJJTreeProjectAndJavaccArgumentsProvidedWhenExecuteCompileJJTreeTaskThenTheFilesAreGeneratedInTheDefaultDirectory()
         throws URISyntaxException, IOException {
-        
+
         CompilationSteps steps = new CompilationSteps();
 
         steps.givenAProjectNamed("simpleJJTreeTestWithArguments");
@@ -125,7 +147,7 @@ public class ThePluginCompilesJjtreeToExpectedDirectoryStory {
     @Test
     public void givenASimpleJJTreeProjectThatConfiguresTheInputOutputDirectoriesWhenExecuteCompileJJTreeTaskThenTheFilesAreGeneratedInTheConfiguredDirectory()
         throws URISyntaxException, IOException {
-        
+
         CompilationSteps steps = new CompilationSteps();
 
         steps.givenAProjectNamed("simpleJJTreeTestWithConfiguredInputsOutputs");
@@ -140,11 +162,11 @@ public class ThePluginCompilesJjtreeToExpectedDirectoryStory {
 
         steps.thenAssertOutputDirectoryDoesNotExists("build" + File.separator + "generated" + File.separator + "javacc");
     }
-    
+
     @Test
     public void givenASimpleJJTreeProjectWhenExecuteCompileJJTreeTaskThenTheFilesThatDoNotHaveACorrespondingCustomAstClassAreGeneratedInTheDefaultDirectory()
         throws URISyntaxException, IOException {
-        
+
         CompilationSteps steps = new CompilationSteps();
 
         steps.givenAProjectNamed("simpleJJTreeTestWithCustomAstClasses");
@@ -161,11 +183,11 @@ public class ThePluginCompilesJjtreeToExpectedDirectoryStory {
 
         steps.thenAssertOutputDirectoryDoesNotExists(buildDirectory + File.separator + "javacc");
     }
-    
+
     @Test
     public void givenASimpleJJTreeProjectWhenRerunCompileJJTreeTaskThenTheFilesThatDoNotHaveACorrespondingCustomAstClassAreGeneratedInTheDefaultDirectory()
         throws URISyntaxException, IOException {
-        
+
         CompilationSteps steps = new CompilationSteps();
 
         steps.givenAProjectNamed("simpleJJTreeTestWithCustomAstClasses");

--- a/subprojects/plugin/src/acceptanceTest/java/javacc/compilation/ThePluginProducesJjdocDocumentationToExpectedDirectory.java
+++ b/subprojects/plugin/src/acceptanceTest/java/javacc/compilation/ThePluginProducesJjdocDocumentationToExpectedDirectory.java
@@ -1,10 +1,10 @@
 package javacc.compilation;
 
+import org.junit.Test;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
-
-import org.junit.Test;
 
 public class ThePluginProducesJjdocDocumentationToExpectedDirectory {
     private static final String CLEAN = "clean";
@@ -33,6 +33,24 @@ public class ThePluginProducesJjdocDocumentationToExpectedDirectory {
         steps.givenAProjectNamed("simpleTest");
         steps.withArguments(CLEAN, JJDOC).execute();
         steps.withArguments(JJDOC).withArguments("--rerun-tasks").execute();
+
+        String buildDirectory = "build" + File.separator + "generated";
+
+        steps.thenAssertOutputDirectoryDoesNotExists(buildDirectory + File.separator + "javacc");
+        steps.thenAssertOutputDirectoryDoesNotExists(buildDirectory + File.separator + "jjtree");
+
+        steps.thenAssertOutputDirectoryExists(buildDirectory + File.separator + JJDOC);
+        steps.andAssertFileWasGenerated("MyParser.html");
+    }
+
+    @Test
+    public void givenASimpleProjectWithGradle33() throws URISyntaxException, IOException {
+        CompilationSteps steps = new CompilationSteps();
+
+        steps.givenAProjectNamed("simpleTest");
+        steps.withArguments(CLEAN, JJDOC).execute();
+        steps.withArguments(JJDOC).withArguments("--rerun-tasks");
+        steps.withGradleVersion("3.3").execute();
 
         String buildDirectory = "build" + File.separator + "generated";
 

--- a/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/AbstractJavaccTask.java
+++ b/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/AbstractJavaccTask.java
@@ -1,8 +1,10 @@
 package ca.coglinc.gradle.plugins.javacc;
 
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.file.FileTree;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
@@ -50,6 +52,14 @@ public abstract class AbstractJavaccTask extends SourceTask {
         } else {
             return inputDirectory;
         }
+    }
+
+    @InputFiles
+    @SkipWhenEmpty
+    @PathSensitive(PathSensitivity.RELATIVE)
+    @Override
+    public FileTree getSource() {
+        return super.getSource();
     }
 
     @OutputDirectory

--- a/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/AbstractJavaccTask.java
+++ b/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/AbstractJavaccTask.java
@@ -1,9 +1,7 @@
 package ca.coglinc.gradle.plugins.javacc;
 
-import java.io.File;
-import java.util.Map;
-
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
@@ -12,6 +10,9 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.SourceTask;
+
+import java.io.File;
+import java.util.Map;
 
 public abstract class AbstractJavaccTask extends SourceTask {
     protected Map<String, String> programArguments;
@@ -27,7 +28,8 @@ public abstract class AbstractJavaccTask extends SourceTask {
         include(filter);
     }
 
-    @Internal
+    @Input
+    @Optional
     public Map<String, String> getArguments() {
         return programArguments;
     }

--- a/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/CompileJavaccTask.java
+++ b/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/CompileJavaccTask.java
@@ -1,18 +1,19 @@
 package ca.coglinc.gradle.plugins.javacc;
 
-import java.io.File;
-
-import org.gradle.api.tasks.TaskAction;
-import org.gradle.api.tasks.TaskCollection;
-import org.gradle.api.tasks.compile.JavaCompile;
-
 import ca.coglinc.gradle.plugins.javacc.compiler.CompilerInputOutputConfiguration;
 import ca.coglinc.gradle.plugins.javacc.compiler.JavaccCompilerInputOutputConfiguration;
 import ca.coglinc.gradle.plugins.javacc.compiler.JavaccSourceFileCompiler;
 import ca.coglinc.gradle.plugins.javacc.compiler.SourceFileCompiler;
 import ca.coglinc.gradle.plugins.javacc.programexecution.JavaccProgramInvoker;
 import ca.coglinc.gradle.plugins.javacc.programexecution.ProgramArguments;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.TaskCollection;
+import org.gradle.api.tasks.compile.JavaCompile;
 
+import java.io.File;
+
+@CacheableTask
 public class CompileJavaccTask extends AbstractJavaccTask {
     public static final String TASK_NAME_VALUE = "compileJavacc";
     public static final String TASK_DESCRIPTION_VALUE = "Compiles JavaCC files into Java files";

--- a/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/CompileJjdocTask.java
+++ b/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/CompileJjdocTask.java
@@ -1,18 +1,19 @@
 package ca.coglinc.gradle.plugins.javacc;
 
-import java.io.File;
-
-import org.gradle.api.tasks.TaskAction;
-import org.gradle.api.tasks.TaskCollection;
-import org.gradle.api.tasks.compile.JavaCompile;
-
 import ca.coglinc.gradle.plugins.javacc.compiler.CompilerInputOutputConfiguration;
 import ca.coglinc.gradle.plugins.javacc.compiler.JavaccCompilerInputOutputConfiguration;
 import ca.coglinc.gradle.plugins.javacc.compiler.JavaccSourceFileCompiler;
 import ca.coglinc.gradle.plugins.javacc.compiler.SourceFileCompiler;
 import ca.coglinc.gradle.plugins.javacc.programexecution.JjdocProgramInvoker;
 import ca.coglinc.gradle.plugins.javacc.programexecution.ProgramArguments;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.TaskCollection;
+import org.gradle.api.tasks.compile.JavaCompile;
 
+import java.io.File;
+
+@CacheableTask
 public class CompileJjdocTask extends AbstractJavaccTask {
     public static final String TASK_NAME_VALUE = "jjdoc";
     public static final String TASK_DESCRIPTION_VALUE = "Takes a JavaCC parser specification and produces documentation for the BNF grammar";

--- a/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/CompileJjtreeTask.java
+++ b/subprojects/plugin/src/main/java/ca/coglinc/gradle/plugins/javacc/CompileJjtreeTask.java
@@ -1,18 +1,19 @@
 package ca.coglinc.gradle.plugins.javacc;
 
-import java.io.File;
-
-import org.gradle.api.tasks.TaskAction;
-import org.gradle.api.tasks.TaskCollection;
-import org.gradle.api.tasks.compile.JavaCompile;
-
 import ca.coglinc.gradle.plugins.javacc.compiler.CompilerInputOutputConfiguration;
 import ca.coglinc.gradle.plugins.javacc.compiler.JavaccCompilerInputOutputConfiguration;
 import ca.coglinc.gradle.plugins.javacc.compiler.JavaccSourceFileCompiler;
 import ca.coglinc.gradle.plugins.javacc.compiler.SourceFileCompiler;
 import ca.coglinc.gradle.plugins.javacc.programexecution.JjtreeProgramInvoker;
 import ca.coglinc.gradle.plugins.javacc.programexecution.ProgramArguments;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.TaskCollection;
+import org.gradle.api.tasks.compile.JavaCompile;
 
+import java.io.File;
+
+@CacheableTask
 public class CompileJjtreeTask extends AbstractJavaccTask {
     public static final String TASK_NAME_VALUE = "compileJjtree";
     public static final String TASK_DESCRIPTION_VALUE = "Compiles JJTree files into JavaCC files";

--- a/subprojects/plugin/src/test/java/ca/coglinc/gradle/plugins/javacc/programexecution/JjdocProgramInvokerTest.java
+++ b/subprojects/plugin/src/test/java/ca/coglinc/gradle/plugins/javacc/programexecution/JjdocProgramInvokerTest.java
@@ -1,5 +1,19 @@
 package ca.coglinc.gradle.plugins.javacc.programexecution;
 
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.file.RelativePath;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -9,18 +23,6 @@ import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import java.io.File;
-import java.io.IOException;
-
-import org.gradle.api.Project;
-import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.file.RelativePath;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
 
 public class JjdocProgramInvokerTest {
 
@@ -85,8 +87,17 @@ public class JjdocProgramInvokerTest {
 
         ProgramArguments augmentedArguments = programInvoker.augmentArguments(inputDirectory, fileToCompile, arguments);
 
-        String expectedOutputFileArgument = String.format("-OUTPUT_FILE=%s/%s.%s", tempOutputDirectory.getAbsolutePath(), "MyClass", extension);
-        assertThat(augmentedArguments.get(augmentedArguments.size() - 1), is(equalTo(expectedOutputFileArgument)));
+        Pattern pathPat = Pattern.compile(String.format("^-OUTPUT_FILE=(.*)[\\\\/]%s\\.%s$", "MyClass", extension));
+
+        String result = augmentedArguments.get(augmentedArguments.size() - 1);
+
+        Matcher matcher = pathPat.matcher(result);
+
+        assertThat(matcher.matches(), is(true));
+
+        String tempPath = matcher.group(1);
+
+        assertThat(tempPath, is(equalTo(tempOutputDirectory.getAbsolutePath())));
     }
 
     @Test


### PR DESCRIPTION
Basically declared the tasks as `@CacheableTask`.

Additionally, added programArgs as input property and declared 'source' property as relative

The gradle version was upgraded to 4.0.2.
Acceptance tests were modified so that they work for gradle 3.3 up to 4.1-rc1.
The simple test cases for jjdoc, jjtree, javacc were replicated to run against gradle 3.3 guaranteeing backwards compatibility even though a newer gradle version is used for building.

This is the Pull-request announced in #42 