### PR TITLE
Remove calls to setMain (deprecated in Gradle 7)

### DIFF
--- a/subprojects/plugin/src/acceptanceTest/java/javacc/compilation/CompilationSteps.java
+++ b/subprojects/plugin/src/acceptanceTest/java/javacc/compilation/CompilationSteps.java
@@ -31,7 +31,7 @@ public class CompilationSteps {
         projectDirectory = new File(resource.toURI());
 
         buildRunner = GradleRunner.create()
-                                  .withGradleVersion("6.0.1")
+                                  .withGradleVersion("6.4")
                                   .withProjectDir(projectDirectory)
                                   .withPluginClasspath();
     }

--- a/subprojects/plugin/src/main/java/org/javacc/plugin/gradle/javacc/programexecution/JavaccExecutorAction.java
+++ b/subprojects/plugin/src/main/java/org/javacc/plugin/gradle/javacc/programexecution/JavaccExecutorAction.java
@@ -18,7 +18,7 @@ class JavaccExecutorAction implements Action<JavaExecSpec> {
     @Override
     public void execute(JavaExecSpec executor) {
         executor.classpath(classpath);
-        executor.setMain("org.javacc.parser.Main");
+        executor.getMainClass().set("org.javacc.parser.Main");
         executor.args((Object[]) arguments.toArray());
         executor.setIgnoreExitValue(true);
     }

--- a/subprojects/plugin/src/main/java/org/javacc/plugin/gradle/javacc/programexecution/JjdocExecutorAction.java
+++ b/subprojects/plugin/src/main/java/org/javacc/plugin/gradle/javacc/programexecution/JjdocExecutorAction.java
@@ -18,7 +18,7 @@ class JjdocExecutorAction implements Action<JavaExecSpec> {
     @Override
     public void execute(JavaExecSpec executor) {
         executor.classpath(classpath);
-        executor.setMain("org.javacc.jjdoc.JJDocMain");
+        executor.getMainClass().set("org.javacc.jjdoc.JJDocMain");
         executor.args((Object[]) arguments.toArray());
         executor.setIgnoreExitValue(true);
     }

--- a/subprojects/plugin/src/main/java/org/javacc/plugin/gradle/javacc/programexecution/JjtreeExecutorAction.java
+++ b/subprojects/plugin/src/main/java/org/javacc/plugin/gradle/javacc/programexecution/JjtreeExecutorAction.java
@@ -18,7 +18,7 @@ class JjtreeExecutorAction implements Action<JavaExecSpec> {
     @Override
     public void execute(JavaExecSpec executor) {
         executor.classpath(classpath);
-        executor.setMain("org.javacc.jjtree.Main");
+        executor.getMainClass().set("org.javacc.jjtree.Main");
         executor.args((Object[]) arguments.toArray());
         executor.setIgnoreExitValue(true);
     }

--- a/subprojects/plugin/src/test/java/org/javacc/plugin/gradle/javacc/programexecution/JavaExecFactory.java
+++ b/subprojects/plugin/src/test/java/org/javacc/plugin/gradle/javacc/programexecution/JavaExecFactory.java
@@ -1,0 +1,18 @@
+package org.javacc.plugin.gradle.javacc.programexecution;
+
+import org.gradle.api.internal.provider.DefaultProperty;
+import org.gradle.api.internal.provider.PropertyHost;
+import org.gradle.api.provider.Property;
+import org.gradle.process.JavaExecSpec;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class JavaExecFactory {
+    public static JavaExecSpec createSpec() {
+        JavaExecSpec spec = mock(JavaExecSpec.class);
+        Property<String> mainClass = new DefaultProperty<>(mock(PropertyHost.class),String.class);
+        when(spec.getMainClass()).thenReturn(mainClass);
+        return spec;
+    }
+}

--- a/subprojects/plugin/src/test/java/org/javacc/plugin/gradle/javacc/programexecution/JavaccExecutorActionTest.java
+++ b/subprojects/plugin/src/test/java/org/javacc/plugin/gradle/javacc/programexecution/JavaccExecutorActionTest.java
@@ -1,5 +1,6 @@
 package org.javacc.plugin.gradle.javacc.programexecution;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -17,7 +18,7 @@ public class JavaccExecutorActionTest {
 
     @Before
     public void setUp() throws Exception {
-        javaExecSpec = mock(JavaExecSpec.class);
+        javaExecSpec = JavaExecFactory.createSpec();
         providedClasspath = mock(Configuration.class);
         providedArguments = new ProgramArguments();
         action = new JavaccExecutorAction(providedClasspath, providedArguments);
@@ -34,7 +35,7 @@ public class JavaccExecutorActionTest {
     public void executorInvokesJavacc() {
         action.execute(javaExecSpec);
 
-        verify(javaExecSpec).setMain("org.javacc.parser.Main");
+        assertEquals("org.javacc.parser.Main", javaExecSpec.getMainClass().get());
     }
 
     @Test

--- a/subprojects/plugin/src/test/java/org/javacc/plugin/gradle/javacc/programexecution/JjdocExecutorActionTest.java
+++ b/subprojects/plugin/src/test/java/org/javacc/plugin/gradle/javacc/programexecution/JjdocExecutorActionTest.java
@@ -1,5 +1,6 @@
 package org.javacc.plugin.gradle.javacc.programexecution;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -17,7 +18,7 @@ public class JjdocExecutorActionTest {
 
     @Before
     public void setUp() throws Exception {
-        javaExecSpec = mock(JavaExecSpec.class);
+        javaExecSpec = JavaExecFactory.createSpec();
         providedClasspath = mock(Configuration.class);
         providedArguments = new ProgramArguments();
         action = new JjdocExecutorAction(providedClasspath, providedArguments);
@@ -34,7 +35,7 @@ public class JjdocExecutorActionTest {
     public void executorInvokesJjdoc() {
         action.execute(javaExecSpec);
 
-        verify(javaExecSpec).setMain("org.javacc.jjdoc.JJDocMain");
+        assertEquals("org.javacc.jjdoc.JJDocMain", javaExecSpec.getMainClass().get());
     }
 
     @Test

--- a/subprojects/plugin/src/test/java/org/javacc/plugin/gradle/javacc/programexecution/JjtreeExecutorActionTest.java
+++ b/subprojects/plugin/src/test/java/org/javacc/plugin/gradle/javacc/programexecution/JjtreeExecutorActionTest.java
@@ -1,5 +1,6 @@
 package org.javacc.plugin.gradle.javacc.programexecution;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -17,7 +18,7 @@ public class JjtreeExecutorActionTest {
 
     @Before
     public void setUp() throws Exception {
-        javaExecSpec = mock(JavaExecSpec.class);
+        javaExecSpec = JavaExecFactory.createSpec();
         providedClasspath = mock(Configuration.class);
         providedArguments = new ProgramArguments();
         action = new JjtreeExecutorAction(providedClasspath, providedArguments);
@@ -34,7 +35,7 @@ public class JjtreeExecutorActionTest {
     public void executorInvokesJjtree() {
         action.execute(javaExecSpec);
 
-        verify(javaExecSpec).setMain("org.javacc.jjtree.Main");
+        assertEquals("org.javacc.jjtree.Main", javaExecSpec.getMainClass().get());
     }
 
     @Test


### PR DESCRIPTION
Fixes #56 

This also increases the minimum Gradle version to 6.4.