### PR TITLE
Change plugin ID to org.javacc.javacc

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To use the Gradle Plugins DSL, add the following lines to your `build.gradle` sc
 
 ```gradle
 plugins {
-  id "org.javacc.plugin.javacc-gradle" version "3.0.0"
+  id "org.javacc.javacc" version "3.0.0"
 }
 ```
 
@@ -128,7 +128,7 @@ The following command can be used to release the project, upload to Maven Centra
 - Build with Gradle 6.4
 
 *Breaking changes*
-- Plugin id changed to 'org.javacc.plugin.javacc-gradle'
+- Plugin id changed to 'org.javacc.javacc'
 - Plugin now requires Gradle 6.0.1 to work
 - Plugin now requies Java 8 or higher
 

--- a/subprojects/plugin/build.gradle
+++ b/subprojects/plugin/build.gradle
@@ -103,7 +103,7 @@ gradlePlugin {
     testSourceSets sourceSets.acceptanceTest
     plugins {
         javaccPlugin {
-            id = 'org.javacc.plugin.javacc-gradle'
+            id = 'org.javacc.javacc'
             implementationClass = 'org.javacc.plugin.gradle.javacc.JavaccPlugin'
         }
     }
@@ -117,7 +117,7 @@ pluginBundle {
 
     plugins {
         javaccPlugin {
-            id = 'org.javacc.plugin.javacc-gradle'
+            id = 'org.javacc.javacc'
             displayName = 'JavaCC Plugin'
         }
     }
@@ -198,7 +198,7 @@ bintray {
             name = releaseVersion
             released = new Date()
             vcsTag = 'javacc-gradle-plugin-' + releaseVersion
-            attributes = ['gradle-plugin': 'org.javacc.plugin.javacc-gradle:org.javacc.plugin:javacc-gradle-plugin']
+            attributes = ['gradle-plugin': 'org.javacc.javacc:org.javacc.plugin:javacc-gradle-plugin']
             gpg {
                 sign = true
                 passphrase = gpgPassphrase

--- a/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/multiprojectBuild/subprojects/subproject1/build.gradle
+++ b/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/multiprojectBuild/subprojects/subproject1/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'eclipse'
-    id 'org.javacc.plugin.javacc-gradle'
+    id 'org.javacc.javacc'
 }
 
 sourceCompatibility = 1.8

--- a/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/multiprojectBuildWithConfiguredInputsOutputs/subprojects/subproject1/build.gradle
+++ b/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/multiprojectBuildWithConfiguredInputsOutputs/subprojects/subproject1/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'eclipse'
-    id 'org.javacc.plugin.javacc-gradle'
+    id 'org.javacc.javacc'
 }
 
 sourceCompatibility = 1.8

--- a/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/multiprojectBuildWithJJTree/subprojects/subproject1/build.gradle
+++ b/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/multiprojectBuildWithJJTree/subprojects/subproject1/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'eclipse'
-    id 'org.javacc.plugin.javacc-gradle'
+    id 'org.javacc.javacc'
 }
 
 sourceCompatibility = 1.8

--- a/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/multiprojectBuildWithJJTreeAndWithConfiguredInputsOutputs/subprojects/subproject1/build.gradle
+++ b/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/multiprojectBuildWithJJTreeAndWithConfiguredInputsOutputs/subprojects/subproject1/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'eclipse'
-    id 'org.javacc.plugin.javacc-gradle'
+    id 'org.javacc.javacc'
 }
 
 sourceCompatibility = 1.8

--- a/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/simpleJJTreeTest/build.gradle
+++ b/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/simpleJJTreeTest/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'eclipse'
-    id 'org.javacc.plugin.javacc-gradle'
+    id 'org.javacc.javacc'
 }
 
 sourceCompatibility = 1.8

--- a/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/simpleJJTreeTestWithArguments/build.gradle
+++ b/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/simpleJJTreeTestWithArguments/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'eclipse'
-    id 'org.javacc.plugin.javacc-gradle'
+    id 'org.javacc.javacc'
 }
 
 sourceCompatibility = 1.8

--- a/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/simpleJJTreeTestWithConfiguredInputsOutputs/build.gradle
+++ b/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/simpleJJTreeTestWithConfiguredInputsOutputs/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'eclipse'
-    id 'org.javacc.plugin.javacc-gradle'
+    id 'org.javacc.javacc'
 }
 
 sourceCompatibility = 1.8

--- a/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/simpleJJTreeTestWithCustomAstClasses/build.gradle
+++ b/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/simpleJJTreeTestWithCustomAstClasses/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'eclipse'
-    id 'org.javacc.plugin.javacc-gradle'
+    id 'org.javacc.javacc'
 }
 
 sourceCompatibility = 1.8

--- a/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/simpleJJTreeTestWithPackages/build.gradle
+++ b/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/simpleJJTreeTestWithPackages/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'eclipse'
-    id 'org.javacc.plugin.javacc-gradle'
+    id 'org.javacc.javacc'
 }
 
 sourceCompatibility = 1.8

--- a/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/simpleTest/build.gradle
+++ b/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/simpleTest/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'eclipse'
-    id 'org.javacc.plugin.javacc-gradle'
+    id 'org.javacc.javacc'
 }
 sourceCompatibility = 1.8
 version = '1.0'

--- a/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/simpleTestWithArguments/build.gradle
+++ b/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/simpleTestWithArguments/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'eclipse'
-    id 'org.javacc.plugin.javacc-gradle'
+    id 'org.javacc.javacc'
 }
 
 sourceCompatibility = 1.8

--- a/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/simpleTestWithConfiguredInputsOutputs/build.gradle
+++ b/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/simpleTestWithConfiguredInputsOutputs/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'eclipse'
-    id 'org.javacc.plugin.javacc-gradle'
+    id 'org.javacc.javacc'
 }
 
 sourceCompatibility = 1.8

--- a/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/simpleTestWithCustomAstClass/build.gradle
+++ b/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/simpleTestWithCustomAstClass/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'eclipse'
-    id 'org.javacc.plugin.javacc-gradle'
+    id 'org.javacc.javacc'
 }
 
 sourceCompatibility = 1.8

--- a/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/simpleTestWithEmptyInputDirectory/build.gradle
+++ b/subprojects/plugin/src/acceptanceTest/resources/javacc/compilation/projects/simpleTestWithEmptyInputDirectory/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'eclipse'
-    id 'org.javacc.plugin.javacc-gradle'
+    id 'org.javacc.javacc'
 }
 sourceCompatibility = 1.8
 version = '1.0'


### PR DESCRIPTION
Fixes #52 , avoiding words "gradle" and "plugin" in Gradle plugin ID.