### PR TITLE
Optimize tree lookup for custom AST files

### DIFF
--- a/subprojects/plugin/src/main/java/org/javacc/plugin/gradle/javacc/compilationresults/CompiledJavaccFilesDirectory.java
+++ b/subprojects/plugin/src/main/java/org/javacc/plugin/gradle/javacc/compilationresults/CompiledJavaccFilesDirectory.java
@@ -6,18 +6,15 @@ import java.util.Collection;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
-import org.gradle.api.file.FileTree;
 import org.gradle.api.logging.Logger;
 
 public class CompiledJavaccFilesDirectory {
     private File outputDirectory;
-    private FileTree customAstClassesDirectory;
     private File targetDirectory;
     private Logger logger;
 
-    CompiledJavaccFilesDirectory(File outputDirectory, FileTree customAstClassesDirectory, File targetDirectory, Logger logger) {
+    CompiledJavaccFilesDirectory(File outputDirectory, File targetDirectory, Logger logger) {
         this.outputDirectory = outputDirectory;
-        this.customAstClassesDirectory = customAstClassesDirectory;
         this.targetDirectory = targetDirectory;
         this.logger = logger;
     }
@@ -27,7 +24,7 @@ public class CompiledJavaccFilesDirectory {
         Collection<CompiledJavaccFile> compiledJavaccFiles = new ArrayList<>();
 
         for (File file : files) {
-            CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+            CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, targetDirectory, logger);
             compiledJavaccFiles.add(compiledJavaccFile);
         }
 

--- a/subprojects/plugin/src/main/java/org/javacc/plugin/gradle/javacc/compilationresults/CompiledJavaccFilesDirectoryFactory.java
+++ b/subprojects/plugin/src/main/java/org/javacc/plugin/gradle/javacc/compilationresults/CompiledJavaccFilesDirectoryFactory.java
@@ -2,24 +2,19 @@ package org.javacc.plugin.gradle.javacc.compilationresults;
 
 import java.io.File;
 
-import org.gradle.api.file.FileTree;
 import org.gradle.api.logging.Logger;
 
 public class CompiledJavaccFilesDirectoryFactory {
 
-    public CompiledJavaccFilesDirectory getCompiledJavaccFilesDirectory(File outputDirectory, FileTree customAstClassesDirectory, File targetDirectory, Logger logger) {
+    public CompiledJavaccFilesDirectory getCompiledJavaccFilesDirectory(File outputDirectory, File targetDirectory, Logger logger) {
         if ((outputDirectory == null) || !outputDirectory.exists() || !outputDirectory.isDirectory()) {
             throw new IllegalArgumentException("outputDirectory [" + outputDirectory + "] must be an existing directory");
         }
-        
-        if (customAstClassesDirectory == null) {
-            throw new IllegalArgumentException("customAstClassesDirectory [" + outputDirectory + "] must not be null");
-        }
-        
+
         if ((targetDirectory == null) || !targetDirectory.exists() || !targetDirectory.isDirectory()) {
             throw new IllegalArgumentException("targetDirectory [" + targetDirectory + "] must be an existing directory");
         }
-        
-        return new CompiledJavaccFilesDirectory(outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+
+        return new CompiledJavaccFilesDirectory(outputDirectory, targetDirectory, logger);
     }
 }

--- a/subprojects/plugin/src/main/java/org/javacc/plugin/gradle/javacc/compiler/JavaccCompilerInputOutputConfiguration.java
+++ b/subprojects/plugin/src/main/java/org/javacc/plugin/gradle/javacc/compiler/JavaccCompilerInputOutputConfiguration.java
@@ -81,10 +81,9 @@ public class JavaccCompilerInputOutputConfiguration implements CompilerInputOutp
             return null;
         }
 
-        Spec<File> outputDirectoryFilter = file -> file.getAbsolutePath()
+        Spec<File> notInOutputDirectory = file -> !file.getAbsolutePath()
             .contains(getOutputDirectory().getAbsolutePath());
 
-        FileTree fileTree = sourceTree.minus(sourceTree.filter(outputDirectoryFilter)).getAsFileTree();
-        return fileTree;
+        return sourceTree.filter(notInOutputDirectory).getAsFileTree();
     }
 }

--- a/subprojects/plugin/src/test/java/org/javacc/plugin/gradle/javacc/compilationresults/CompiledJavaccFileTest.java
+++ b/subprojects/plugin/src/test/java/org/javacc/plugin/gradle/javacc/compilationresults/CompiledJavaccFileTest.java
@@ -2,22 +2,23 @@ package org.javacc.plugin.gradle.javacc.compilationresults;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.doThrow;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
-import org.gradle.api.file.FileTree;
 import org.gradle.api.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
@@ -32,7 +33,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @PrepareForTest(FileUtils.class)
 public class CompiledJavaccFileTest {
     private File outputDirectory;
-    private FileTree customAstClassesDirectory;
+    private Collection<File> customAstClassesDirectory;
     private File targetDirectory;
     private Logger logger;
 
@@ -44,8 +45,7 @@ public class CompiledJavaccFileTest {
 
         Set<File> sourceTree = new HashSet<>();
         sourceTree.add(new File(getClass().getResource("/compiledJavaccFile/customAstClasses").getFile()));
-        customAstClassesDirectory = mock(FileTree.class);
-        when(customAstClassesDirectory.getFiles()).thenReturn(sourceTree);
+        customAstClassesDirectory = sourceTree;
     }
 
     @After
@@ -57,51 +57,51 @@ public class CompiledJavaccFileTest {
     @Test
     public void customAstClassDoesNotExist() {
         File file = new File(outputDirectory, "FileWithNoCorrespondingCustomAstClass.java");
-        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, targetDirectory, logger);
 
-        boolean customAstClassExists = compiledJavaccFile.customAstClassExists();
+        File customAstFile = compiledJavaccFile.getCustomAstClassInputFile(customAstClassesDirectory);
 
-        assertFalse(customAstClassExists);
+        assertNull(customAstFile);
     }
 
     @Test
     public void customAstClassExists() {
         File file = new File(outputDirectory, "FileWithCorrespondingCustomAstClass.java");
-        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, targetDirectory, logger);
 
-        boolean customAstClassExists = compiledJavaccFile.customAstClassExists();
+        File customAstFile = compiledJavaccFile.getCustomAstClassInputFile(customAstClassesDirectory);
 
-        assertTrue(customAstClassExists);
+        assertNotNull(customAstFile);
     }
 
     @Test
     public void customAstClassDoesNotExistInSpecificDirectory() {
         File file = new File(outputDirectory, "FileWithNoCorrespondingCustomAstClass.java");
-        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, targetDirectory, logger);
 
-        boolean customAstClassExists = compiledJavaccFile.customAstClassExists(customAstClassesDirectory);
+        File customAstClassExists = compiledJavaccFile.getCustomAstClassInputFile(customAstClassesDirectory);
 
-        assertFalse(customAstClassExists);
+        assertNull(customAstClassExists);
     }
 
     @Test
     public void customAstClassExistsInSpecificDirectory() {
         File file = new File(outputDirectory, "FileWithCorrespondingCustomAstClass.java");
-        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, targetDirectory, logger);
 
-        boolean customAstClassExists = compiledJavaccFile.customAstClassExists(customAstClassesDirectory);
+        File customAstClassExists = compiledJavaccFile.getCustomAstClassInputFile(customAstClassesDirectory);
 
-        assertTrue(customAstClassExists);
+        assertNotNull(customAstClassExists);
     }
 
     @Test
     public void customAstClassCantExistInNullDirectory() {
         File file = new File(outputDirectory, "FileWithCorrespondingCustomAstClass.java");
-        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, targetDirectory, logger);
 
-        boolean customAstClassExists = compiledJavaccFile.customAstClassExists(null);
+        File customAstClassExists = compiledJavaccFile.getCustomAstClassInputFile(null);
 
-        assertFalse(customAstClassExists);
+        assertNull(customAstClassExists);
     }
 
     @Test
@@ -110,7 +110,7 @@ public class CompiledJavaccFileTest {
         assertFalse(expectedFile.exists());
 
         File file = new File(outputDirectory, "FileWithNoCorrespondingCustomAstClass.java");
-        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, targetDirectory, logger);
 
         compiledJavaccFile.copyCompiledFileToTargetDirectory();
 
@@ -120,7 +120,7 @@ public class CompiledJavaccFileTest {
     @Test(expected = CompiledJavaccFileOperationException.class)
     public void copyCompiledFileToTargetDirectoryFails() {
         File file = new File(outputDirectory, "DoesNotExist.java");
-        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, targetDirectory, logger);
 
         compiledJavaccFile.copyCompiledFileToTargetDirectory();
     }
@@ -131,9 +131,9 @@ public class CompiledJavaccFileTest {
         assertFalse(expectedFile.exists());
 
         File file = new File(outputDirectory, "FileWithCorrespondingCustomAstClass.java");
-        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, targetDirectory, logger);
 
-        compiledJavaccFile.copyCustomAstClassToTargetDirectory(customAstClassesDirectory);
+        compiledJavaccFile.handleCustomAstInJavacc(customAstClassesDirectory);
 
         assertTrue(expectedFile.exists());
     }
@@ -145,15 +145,15 @@ public class CompiledJavaccFileTest {
         FileUtils.copyFile(any(File.class), any(File.class));
 
         File file = new File(outputDirectory, "FileWithCorrespondingCustomAstClass.java");
-        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, targetDirectory, logger);
 
-        compiledJavaccFile.copyCustomAstClassToTargetDirectory(customAstClassesDirectory);
+        compiledJavaccFile.handleCustomAstInJavacc(customAstClassesDirectory);
     }
 
     @Test
     public void toStringReturnsAbsoluteFileName() {
         File file = new File(outputDirectory, "FileWithCorrespondingCustomAstClass.java");
-        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, targetDirectory, logger);
 
         String stringValue = compiledJavaccFile.toString();
 
@@ -163,10 +163,9 @@ public class CompiledJavaccFileTest {
     @Test
     public void ignoreCompiledFileAndUseCustomAstClassFromJavaSourceTreeOnlyLogsThatCompiledFileIsNotActedUpon() {
         File file = mock(File.class);
-        FileTree javaSourceTree = mock(FileTree.class);
-        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, customAstClassesDirectory, targetDirectory, logger);
+        CompiledJavaccFile compiledJavaccFile = new CompiledJavaccFile(file, outputDirectory, targetDirectory, logger);
 
-        compiledJavaccFile.ignoreCompiledFileAndUseCustomAstClassFromJavaSourceTree(javaSourceTree);
+        compiledJavaccFile.ignoreCompiledFileAndUseCustomAstClassFromJavaSourceTree(file);
 
         verify(logger).info(anyString(), eq(file), anyString());
     }

--- a/subprojects/plugin/src/test/java/org/javacc/plugin/gradle/javacc/compilationresults/CompiledJavaccFilesDirectoryFactoryTest.java
+++ b/subprojects/plugin/src/test/java/org/javacc/plugin/gradle/javacc/compilationresults/CompiledJavaccFilesDirectoryFactoryTest.java
@@ -32,51 +32,46 @@ public class CompiledJavaccFilesDirectoryFactoryTest {
 
     @Test
     public void createInstance() {
-        CompiledJavaccFilesDirectory directory = factory.getCompiledJavaccFilesDirectory(outputDirectory, customAstClassesDirectory, targetDirectory, null);
+        CompiledJavaccFilesDirectory directory = factory.getCompiledJavaccFilesDirectory(outputDirectory, targetDirectory, null);
 
         assertNotNull(directory);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void outputDirectoryMustBeProvided() {
-        factory.getCompiledJavaccFilesDirectory(null, customAstClassesDirectory, targetDirectory, null);
+        factory.getCompiledJavaccFilesDirectory(null, targetDirectory, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void outputDirectoryMustExist() {
         File inexistingOutputDirectory = new File(getClass().getResource("/").getFile() + "doesNotExist");
 
-        factory.getCompiledJavaccFilesDirectory(inexistingOutputDirectory, customAstClassesDirectory, targetDirectory, null);
+        factory.getCompiledJavaccFilesDirectory(inexistingOutputDirectory, targetDirectory, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void outputDirectoryMustBeADirectory() {
         File invalidOutputDirectory = new File(getClass().getResource("/javacc/input/JavaccOutputTest.jj").getFile());
 
-        factory.getCompiledJavaccFilesDirectory(invalidOutputDirectory, customAstClassesDirectory, targetDirectory, null);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void customAstClassesDirectoryMustBeProvided() {
-        factory.getCompiledJavaccFilesDirectory(outputDirectory, null, targetDirectory, null);
+        factory.getCompiledJavaccFilesDirectory(invalidOutputDirectory, targetDirectory, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void targetDirectoryMustBeProvided() {
-        factory.getCompiledJavaccFilesDirectory(outputDirectory, customAstClassesDirectory, null, null);
+        factory.getCompiledJavaccFilesDirectory(outputDirectory, null, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void targetDirectoryMustExist() {
         File inexistingOutputDirectory = new File(getClass().getResource("/").getFile() + "doesNotExist");
 
-        factory.getCompiledJavaccFilesDirectory(outputDirectory, customAstClassesDirectory, inexistingOutputDirectory, null);
+        factory.getCompiledJavaccFilesDirectory(outputDirectory, inexistingOutputDirectory, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void targetDirectoryMustBeADirectory() {
         File invalidOutputDirectory = new File(getClass().getResource("/javacc/input/JavaccOutputTest.jj").getFile());
 
-        factory.getCompiledJavaccFilesDirectory(outputDirectory, customAstClassesDirectory, invalidOutputDirectory, null);
+        factory.getCompiledJavaccFilesDirectory(outputDirectory, invalidOutputDirectory, null);
     }
 }

--- a/subprojects/plugin/src/test/java/org/javacc/plugin/gradle/javacc/compilationresults/CompiledJavaccFilesDirectoryTest.java
+++ b/subprojects/plugin/src/test/java/org/javacc/plugin/gradle/javacc/compilationresults/CompiledJavaccFilesDirectoryTest.java
@@ -15,40 +15,40 @@ public class CompiledJavaccFilesDirectoryTest {
 
     @Test
     public void listFilesReturnsEmptyCollectionForEmptyDirectory() {
-        CompiledJavaccFilesDirectory directory = new CompiledJavaccFilesDirectory(new File(getClass().getResource("/empty").getFile()), null, null, null);
-        
+        CompiledJavaccFilesDirectory directory = new CompiledJavaccFilesDirectory(new File(getClass().getResource("/empty").getFile()), null, null);
+
         Collection<CompiledJavaccFile> files = directory.listFiles();
-        
+
         assertThat(files, is(empty()));
     }
-    
+
     @Test
     public void listFilesReturnsAllFiles() {
-        CompiledJavaccFilesDirectory directory = new CompiledJavaccFilesDirectory(new File(getClass().getResource("/compiledResults").getFile()), null, null, null);
-        
+        CompiledJavaccFilesDirectory directory = new CompiledJavaccFilesDirectory(new File(getClass().getResource("/compiledResults").getFile()), null, null);
+
         Collection<CompiledJavaccFile> files = directory.listFiles();
-        
+
         final int numberOfFilesInFolder = 2;
         assertThat(files, hasSize(numberOfFilesInFolder));
     }
-    
+
     @Test
     public void listFilesReturnsAllFilesRecursively() {
-        CompiledJavaccFilesDirectory directory = new CompiledJavaccFilesDirectory(new File(getClass().getResource("/compiledResultsWithSubFolders").getFile()), null, null, null);
-        
+        CompiledJavaccFilesDirectory directory = new CompiledJavaccFilesDirectory(new File(getClass().getResource("/compiledResultsWithSubFolders").getFile()),  null, null);
+
         Collection<CompiledJavaccFile> files = directory.listFiles();
-        
+
         final int numberOfFilesInFolder = 3;
         assertThat(files, hasSize(numberOfFilesInFolder));
     }
-    
+
     @Test
     public void toStringReturnsAbsoluteDirectoryPath() {
         File outputDirectory = new File(getClass().getResource("/compiledResults").getFile());
-        CompiledJavaccFilesDirectory directory = new CompiledJavaccFilesDirectory(outputDirectory, null, null, null);
-        
+        CompiledJavaccFilesDirectory directory = new CompiledJavaccFilesDirectory(outputDirectory,  null, null);
+
         String stringValue = directory.toString();
-        
+
         assertEquals(outputDirectory.getAbsolutePath(), stringValue);
     }
 }

--- a/subprojects/plugin/src/test/java/org/javacc/plugin/gradle/javacc/programexecution/JavaccProgramInvokerTest.java
+++ b/subprojects/plugin/src/test/java/org/javacc/plugin/gradle/javacc/programexecution/JavaccProgramInvokerTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.contains;
 import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -15,6 +16,7 @@ import java.io.IOException;
 
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.RelativePath;
 import org.junit.Before;
 import org.junit.Rule;
@@ -37,6 +39,7 @@ public class JavaccProgramInvokerTest {
     @Before
     public void setUp() throws Exception {
         project = mock(Project.class);
+        doReturn(mock(ConfigurationContainer.class)).when(project).getConfigurations();
         Configuration classpath = mock(Configuration.class);
         tempOutputDirectory = testFolder.newFolder("tempOutput");
         programInvoker = new JavaccProgramInvoker(project, classpath, tempOutputDirectory);


### PR DESCRIPTION
Since the bugfix for #15 the plugin spends a lot of time looking for existing AST files, in big projects this can be ~1 minute (compared to ~20s to actually compile the parser....). This PR does a few optimizations:
* collect the files only once, not once per compiler output file
* scan the collection once per file
* don't scan two overlapping collections, but only the disjoint parts